### PR TITLE
Feature/BBL-242 | ansible image dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
+MAKEFILES_VER := v0.0.67
 
 define DOCKER_IMG_LIST
+"ansible" \
+"ansible-dev" \
 "git-release" \
 "terraform-awscli" \
 "terraform-awscli-slim" \
@@ -21,7 +24,8 @@ help:
 init-makefiles: ## initialize makefiles
 	rm -rf ${MAKEFILES_DIR}
 	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
+	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR} -q
+	cd ${MAKEFILES_DIR} && git checkout ${MAKEFILES_VER} -q
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk

--- a/ansible-dev/Dockerfile
+++ b/ansible-dev/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.8-slim-buster
+LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
+
+ARG DOCKER_TAG
+ARG ANSIBLE_VERSION=${DOCKER_TAG}
+
+ENV PY_PIP_VER=20.2.4
+ENV PY_PIP_PKGS="ansible==${ANSIBLE_VERSION} yamllint ansible-lint flake8 molecule"
+
+#
+# Installing dependencies
+#
+RUN apt-get update \
+  && apt-get install -y git \
+	&& apt-get clean
+
+# Install Ansible via Pip.
+RUN pip3 install --upgrade pip==${PY_PIP_VER}
+RUN pip3 install wheel
+RUN pip3 install ${PY_PIP_PKGS}
+
+# Remove unnecessary getty and udev targets that result in high CPU usage when using
+# multiple containers with Molecule (https://github.com/ansible/molecule/issues/1104)
+RUN rm -f /lib/systemd/system/systemd*udev* \
+  && rm -f /lib/systemd/system/getty.target
+
+ENTRYPOINT ["ansible"]

--- a/ansible-dev/Makefile
+++ b/ansible-dev/Makefile
@@ -1,0 +1,44 @@
+.PHONY: build
+SHELL            := /bin/bash
+MAKEFILES_DIR    := ../@bin/makefiles
+
+DOCKER_TAG       := 2.10.3
+DOCKER_REPO_NAME := binbash
+DOCKER_IMG_NAME  := ansible-dev
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
+
+shell: ## interactive shell terminal
+	docker run -it --rm --entrypoint=bash \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+
+#
+# docker run tests
+#
+run-python-version: ## docker run python --version
+	docker run -it --rm --entrypoint=python \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-ansible-version: ## docker run ansible --version
+	docker run -it --rm \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-molecule-version: ## docker run molecule --version
+	docker run -it --rm --entrypoint=molecule \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-yamllint-version: ## docker run yamllint --version
+	docker run -it --rm --entrypoint=yamllint \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-ansible-lint-version: ## docker run ansible-lint --version
+	docker run -it --rm --entrypoint=ansible-lint \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-all: run-python-version run-ansible-version run-molecule-version run-yamllint-version run-ansible-lint-version
+
+test: run-all ## ci docker image tests

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.8-slim-buster
+LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
+
+ARG DOCKER_TAG
+ARG ANSIBLE_VERSION=${DOCKER_TAG}
+
+ENV PY_PIP_VER=20.2.4
+ENV PY_PIP_PKGS="ansible==${ANSIBLE_VERSION}"
+
+#
+# Installing dependencies
+#
+RUN apt-get update \
+  && apt-get install -y git \
+	&& apt-get clean
+
+# Install Ansible via Pip.
+RUN pip3 install --upgrade pip==${PY_PIP_VER}
+RUN pip3 install wheel
+RUN pip3 install ${PY_PIP_PKGS}
+
+# Remove unnecessary getty and udev targets that result in high CPU usage when using
+# multiple containers with Molecule (https://github.com/ansible/molecule/issues/1104)
+RUN rm -f /lib/systemd/system/systemd*udev* \
+  && rm -f /lib/systemd/system/getty.target
+
+ENTRYPOINT ["ansible"]

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,0 +1,32 @@
+.PHONY: build
+SHELL            := /bin/bash
+MAKEFILES_DIR    := ../@bin/makefiles
+
+DOCKER_TAG       := 2.10.3
+DOCKER_REPO_NAME := binbash
+DOCKER_IMG_NAME  := ansible
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
+
+shell: ## interactive shell terminal
+	docker run -it --rm --entrypoint=bash \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+
+#
+# docker run tests
+#
+run-python-version: ## docker run python --version
+	docker run -it --rm --entrypoint=python \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-ansible-version: ## docker run terraform --version
+	docker run -it --rm \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+run-all: run-python-version run-ansible-version
+
+test: run-all ## ci docker image tests

--- a/git-release/Makefile
+++ b/git-release/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build
 SHELL            := /bin/bash
-MAKEFILE_PATH    := ./Makefile
 MAKEFILES_DIR    := ../@bin/makefiles
 
 DOCKER_TAG       := 0.0.2
@@ -13,14 +12,6 @@ DOCKER_SEMTAG_CMD := /opt/semtag/semtag/semtag
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
-
-#==============================================================#
-# INITIALIZATION                                               #
-#==============================================================#
-init-makefiles: ## initialize makefiles
-	rm -rf ${MAKEFILES_DIR}
-	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
 
 -include ${MAKEFILES_DIR}/docker/docker-hub-build-push.mk
 

--- a/terraform-awscli-slim/Makefile
+++ b/terraform-awscli-slim/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build
 SHELL            := /bin/bash
-MAKEFILE_PATH    := ./Makefile
 MAKEFILES_DIR    := ../@bin/makefiles
 
 DOCKER_TAG       := 0.13.2
@@ -24,14 +23,6 @@ endef
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
-
-#==============================================================#
-# INITIALIZATION                                               #
-#==============================================================#
-init-makefiles: ## initialize makefiles
-	rm -rf ${MAKEFILES_DIR}
-	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
 
 -include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
 

--- a/terraform-awscli-terratest-slim/Makefile
+++ b/terraform-awscli-terratest-slim/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build
 SHELL            := /bin/bash
-MAKEFILE_PATH    := ./Makefile
 MAKEFILES_DIR    := ../@bin/makefiles
 
 DOCKER_TAG       := 0.13.2
@@ -10,14 +9,6 @@ DOCKER_IMG_NAME  := terraform-awscli-terratest-slim
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
-
-#==============================================================#
-# INITIALIZATION                                               #
-#==============================================================#
-init-makefiles: ## initialize makefiles
-	rm -rf ${MAKEFILES_DIR}
-	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
 
 -include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
 

--- a/terraform-awscli/Makefile
+++ b/terraform-awscli/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build
 SHELL            := /bin/bash
-MAKEFILE_PATH    := ./Makefile
 MAKEFILES_DIR    := ../@bin/makefiles
 
 DOCKER_TAG       := 0.13.2
@@ -30,14 +29,6 @@ endef
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
-
-#==============================================================#
-# INITIALIZATION                                               #
-#==============================================================#
-init-makefiles: ## initialize makefiles
-	rm -rf ${MAKEFILES_DIR}
-	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
 
 -include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
 

--- a/terraform-resources/Makefile
+++ b/terraform-resources/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build
 SHELL            := /bin/bash
-MAKEFILE_PATH    := ./Makefile
 MAKEFILES_DIR    := ../@bin/makefiles
 
 DOCKER_TAG       := 0.13.2
@@ -10,14 +9,6 @@ DOCKER_IMG_NAME  := terraform-resources
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
-
-#==============================================================#
-# INITIALIZATION                                               #
-#==============================================================#
-init-makefiles: ## initialize makefiles
-	rm -rf ${MAKEFILES_DIR}
-	mkdir -p ${MAKEFILES_DIR}
-	git clone https://github.com/binbashar/le-dev-makefiles.git ${MAKEFILES_DIR}
 
 -include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
 


### PR DESCRIPTION
### What? 
Ansible docker image to address -> https://github.com/binbashar/le-ansible-infra/issues/17

#### Commits on Nov 11, 2020
- @exequielrafaela - BBL-242 | Makefile updated to use versioned approach + adding new docker images for ansible - f582eb9
- @exequielrafaela - BBL-242 | ansible images dockerfiles - 3ed6a06
- @exequielrafaela - BBL-242 | only keeping init-makefiles at the root-context to allow a cleaner approach - b0ce299

### Why?
As exposed at https://github.com/binbashar/le-ansible-infra/issues/17
1. The dockerized Makefile should simplify cmd excecutions and "impose / grant" Binbash Leverage conventions.
2. Standardizing local-env to speed up the on boarding / ramp-up
3. Speed up Leverage development and Binbash Customer Engineers implementation times.
4. In this way we could sum more people to our workflow rapidly, adding the right documentation can reduce the training and KT times.
5. Provide security to protect clients by isolation and standardization.