### PR TITLE
Feature/BBL-424 | terrafom-infracost image + version upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.1.6
+MAKEFILES_VER := v0.1.18
 
 define DOCKER_IMG_LIST
 "ansible" \

--- a/helmsman/Dockerfile
+++ b/helmsman/Dockerfile
@@ -1,0 +1,42 @@
+ARG BASE_HELMSMAN_IMAGE=praqma/helmsman:v3.4.3-helm-v3.2.1
+
+#
+# Build image for aws-iam-authenticator
+#
+FROM alpine:3.12.3 AS aws-iam-authenticator
+LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
+
+# Install aws-iam-authenticator
+WORKDIR /opt
+RUN wget -O aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.2/aws-iam-authenticator_0.5.2_linux_amd64
+RUN chmod +x aws-iam-authenticator
+
+# Install yq
+RUN wget -O yq https://github.com/mikefarah/yq/releases/download/v4.4.0/yq_linux_amd64
+RUN chmod +x yq
+
+
+#
+# Build image for helmsman and helm
+#
+FROM ${BASE_HELMSMAN_IMAGE} AS helmsman
+
+
+#
+# Final image with helmsman, helm and aws-iam-authenticator
+#
+FROM alpine:3.12.3 AS main
+LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
+
+# Copy helmsman and helm from praqma
+COPY --from=helmsman /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=helmsman /bin/helmsman /usr/local/bin/helmsman
+COPY --from=helmsman /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=helmsman /root/.cache/helm/plugins/ /root/.cache/helm/plugins/
+COPY --from=helmsman /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
+
+# Copy aws-iam-authenticator and yq
+COPY --from=aws-iam-authenticator /opt/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
+COPY --from=aws-iam-authenticator /opt/yq /usr/local/bin/yq
+
+ENTRYPOINT ["helmsman"]

--- a/helmsman/Makefile
+++ b/helmsman/Makefile
@@ -6,7 +6,7 @@ DOCKER_ORG 		:= binbash
 DOCKER_IMAGE 	:= helmsman
 DOCKER_TAG 		:= v3.4.3-helm-v3.2.1
 
-BASE_HELMSMAN_IMAGE				:= praqma/helmsman:v3.4.3-helm-v3.2.1
+BASE_HELMSMAN_IMAGE	:= praqma/helmsman:v3.4.3-helm-v3.2.1
 
 
 help:

--- a/helmsman/Makefile
+++ b/helmsman/Makefile
@@ -1,0 +1,38 @@
+.PHONY: build
+SHELL            := /bin/bash
+MAKEFILES_DIR    := ../@bin/makefiles
+
+DOCKER_ORG 		:= binbash
+DOCKER_IMAGE 	:= helmsman
+DOCKER_TAG 		:= v3.4.3-helm-v3.2.1
+
+BASE_HELMSMAN_IMAGE				:= praqma/helmsman:v3.4.3-helm-v3.2.1
+
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
+
+build: ## Build main image
+	docker build -t ${DOCKER_ORG}/${DOCKER_IMAGE}:${DOCKER_TAG} \
+		--build-arg BASE_HELMSMAN_IMAGE=${BASE_HELMSMAN_IMAGE} \
+		--target main \
+		.
+
+#
+# docker run tests
+#
+get-all-versions: ## Get helmsman, helm and aws-iam-authenticator version
+	docker run -it --rm \
+		${DOCKER_ORG}/${DOCKER_IMAGE}:${DOCKER_TAG} -v
+	docker run -it --rm \
+		--entrypoint helm \
+		${DOCKER_ORG}/${DOCKER_IMAGE}:${DOCKER_TAG} version
+	docker run -it --rm \
+		--entrypoint aws-iam-authenticator \
+		${DOCKER_ORG}/${DOCKER_IMAGE}:${DOCKER_TAG} version
+
+test: get-all-versions ## ci docker image tests
+

--- a/terraform-awscli-slim/Dockerfile
+++ b/terraform-awscli-slim/Dockerfile
@@ -5,7 +5,7 @@ FROM hashicorp/terraform:${TERRAFORM_VERSION}
 
 LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
 
-ARG AWSCLI_VERSION=1.18.156
+ARG AWSCLI_VERSION=1.18.216
 
 # Install python3 and other useful dependencies
 RUN apk update

--- a/terraform-awscli-slim/Makefile
+++ b/terraform-awscli-slim/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.14.2
+DOCKER_TAG       := 0.14.4
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli-slim
 

--- a/terraform-awscli-terratest-slim/Makefile
+++ b/terraform-awscli-terratest-slim/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.14.2
+DOCKER_TAG       := 0.14.4
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli-terratest-slim
 

--- a/terraform-awscli/Makefile
+++ b/terraform-awscli/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.13.5
+DOCKER_TAG       := 0.13.6
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli
 

--- a/terraform-infracost-slim/Dockerfile
+++ b/terraform-infracost-slim/Dockerfile
@@ -1,0 +1,30 @@
+ARG DOCKER_TAG
+ARG TERRAFORM_VERSION=${DOCKER_TAG}
+
+FROM hashicorp/terraform:${TERRAFORM_VERSION}
+
+LABEL vendor="Binbash Leverage (info@binbash.com.ar)"
+
+ARG INFRACOST_VERSION="v0.7.13"
+
+# Install python3 and other useful dependencies
+RUN apk update
+RUN set -ex && \
+        apk add ca-certificates && update-ca-certificates && \
+	apk add --no-cache --update \
+        curl \
+        unzip \
+        bash \
+        make \
+        tree \
+        tzdata \
+        jq \
+        oath-toolkit-oathtool \
+        python3
+RUN rm /var/cache/apk/*
+
+# Install specific infracos.io linux version
+RUN curl -s -L https://github.com/infracost/infracost/releases/download/${INFRACOST_VERSION}/infracost-linux-amd64.tar.gz | tar xz -C /tmp && \
+mv /tmp/infracost-linux-amd64 /usr/local/bin/infracost
+
+ENTRYPOINT ["terraform"]

--- a/terraform-infracost-slim/Makefile
+++ b/terraform-infracost-slim/Makefile
@@ -1,0 +1,45 @@
+.PHONY: build
+SHELL            := /bin/bash
+MAKEFILES_DIR    := ../@bin/makefiles
+
+DOCKER_TAG       := 0.14.4
+DOCKER_REPO_NAME := binbash
+DOCKER_IMG_NAME  := terraform-infracost-slim
+
+LOCAL_OS_AWS_CONF_DIR 			:= ~/.aws/bb
+AWS_REGION            			:= us-east-1
+AWS_IAM_PROFILE       		 	:= bb-apps-devstg-devops
+INFRACOST_DOCKER_ENTRYPOINT := infracost
+
+define INFRACOST_CMD_PREFIX
+docker run -it --rm \
+--name ${DOCKER_IMG_NAME} \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+-e "AWS_DEFAULT_REGION=us-east-1" \
+--entrypoint=${INFRACOST_DOCKER_ENTRYPOINT} \
+${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+endef
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
+
+#
+# docker run tests
+#
+
+# infracost
+#
+run-infracost-version: ## docker run infracost --version
+	${INFRACOST_CMD_PREFIX} --version
+
+# terraform & python
+#
+run-terraform-version: ## docker run terraform --version
+	docker run -it --rm \
+	${DOCKER_REPO_NAME}/${DOCKER_IMG_NAME}:${DOCKER_TAG} --version
+
+test: run-terraform-version run-infracost-version  ## ci docker image tests
+

--- a/terraform-resources/Makefile
+++ b/terraform-resources/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.13.5
+DOCKER_TAG       := 0.13.6
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-resources
 


### PR DESCRIPTION
## What?
### Commits on Jan 20, 2021
- @exequielrafaela - BBL-424 | legacy leverage terraform images updated to latest stable tf 0.13.6 - 3a81d8c
- @exequielrafaela - BBL-424 | upgrading terraform images to its latest version + awscli ver upgrade - af2ca1e
- @exequielrafaela - BBL-424 | adding terraform-infracost-slim image for terraform cost plan estimations - f194f31

## Why?
- [BBL-424 | Implement and test infracost tool w/ CI](https://trello.com/c/zkG7EvDf/424-bbl-424-implement-and-test-infracost-tool-w-ci)