### PR TITLE
Add unzip to Ansible docker images

### DIFF
--- a/ansible-dev/Dockerfile
+++ b/ansible-dev/Dockerfile
@@ -11,7 +11,7 @@ ENV PY_PIP_PKGS="ansible==${ANSIBLE_VERSION} yamllint ansible-lint flake8 molecu
 # Installing dependencies
 #
 RUN apt-get update \
-  && apt-get install -y git \
+  && apt-get install -y git unzip \
 	&& apt-get clean
 
 # Install Ansible via Pip.

--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -11,7 +11,7 @@ ENV PY_PIP_PKGS="ansible==${ANSIBLE_VERSION} jmespath==0.10.0"
 # Installing dependencies
 #
 RUN apt-get update \
-  && apt-get install -y git \
+  && apt-get install -y git unzip \
 	&& apt-get clean
 
 # Install Ansible via Pip.


### PR DESCRIPTION
## what
* Add unzip to Ansible docker images

## why
* It is needed by the ansible role that installs Hashicorp Vault