### PR TITLE
Add MFA script to terrafrom-awscli image

### DIFF
--- a/terraform-awscli-slim/Dockerfile
+++ b/terraform-awscli-slim/Dockerfile
@@ -34,4 +34,8 @@ RUN curl -LO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubect
         chmod +x kubectl && \
         mv kubectl /usr/local/bin
 
+# Add aws-mfa script
+RUN mkdir -p /root/scripts/aws-mfa && \
+        curl https://raw.githubusercontent.com/binbashar/le-tf-infra-aws-template/master/le-resources/scripts/aws-mfa/aws-mfa-entrypoint.sh > /root/scripts/aws-mfa/aws-mfa-entrypoint.sh
+
 ENTRYPOINT ["terraform"]


### PR DESCRIPTION
## what
* Package MFA script in terraform-awscli image

## why
* Most Terraform operations done via Leverage CLI require multi factor authentication. This script cannot be packaged in the application and run externally to the container due to security concerns, and leaving this script as part of the project template to be mounted upon execution would only clutter the template, so the only reasonable option remaining is to package the script with the image to allow its use.

