### PR TITLE
BBL-192 | terraform docker image updated to lastes 0.15.x version

### DIFF
--- a/terraform-awscli-slim/Makefile
+++ b/terraform-awscli-slim/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.15.2
+DOCKER_TAG       := 0.15.5
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli-slim
 


### PR DESCRIPTION
### What?
#### Commits on Jul 12, 2021
- @exequielrafaela - BBL-192 | terraform docker image updated to lastes 0.15.x version - eb1a7b5

### Why?
- Le demo-apps workflows imple