### PR TITLE
Add leverage-cli-testing image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ define DOCKER_IMG_LIST
 "ansible" \
 "ansible-dev" \
 "git-release" \
+"leverage-cli-testing" \
 "terraform-awscli-slim" \
 "terraform-awscli-terratest-slim" \
 "helmsman"

--- a/leverage-cli-testing/Dockerfile
+++ b/leverage-cli-testing/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8-slim
+
+LABEL vendor="Binbash Leverage (leverage@binbash.com.ar)"
+
+RUN apt-get update &&\
+    apt-get install -y git curl
+
+# Install bats as node package
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g bats
+## Install bats from source
+# RUN git clone https://github.com/bats-core/bats-core.git /opt/bats
+# RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
+# Install other bats modules
+RUN npm install -g --save-dev https://github.com/bats-core/bats-support
+RUN npm install -g --save-dev https://github.com/bats-core/bats-assert
+
+WORKDIR /leverage
+# Install requirements for running unit tests
+RUN curl -LO https://raw.githubusercontent.com/binbashar/leverage/master/dev-requirements.txt
+RUN pip install -r dev-requirements.txt
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/leverage-cli-testing/Makefile
+++ b/leverage-cli-testing/Makefile
@@ -1,0 +1,13 @@
+.PHONY: help build
+SHELL			 := /bin/bash
+MAKEFILES_DIR	 := ../@bin/makefiles
+
+DOCKER_TAG		 := 1.0.0
+DOCKER_REPO_NAME := binbash
+DOCKER_IMG_NAME  := leverage-cli-testing
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push.mk


### PR DESCRIPTION
## What?
* Add a docker image for Leverage CLI testing

## Why?
* Simplifies testing in Leverage CLI
* Having the image in dockerhub allows to pull it eliminating the need of building it every time

