### PR TITLE
Feature | Base leverage testing image on dind

### DIFF
--- a/leverage-cli-testing/Dockerfile
+++ b/leverage-cli-testing/Dockerfile
@@ -1,24 +1,27 @@
-FROM python:3.8-slim
+FROM docker:dind
 
 LABEL vendor="Binbash Leverage (leverage@binbash.com.ar)"
 
-RUN apt-get update &&\
-    apt-get install -y git curl
+RUN apk update &&\
+    apk add --no-cache bash bash-completion ncurses git curl gcc musl-dev python3 python3-dev py3-pip
 
-# Install bats as node package
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g bats
-## Install bats from source
-# RUN git clone https://github.com/bats-core/bats-core.git /opt/bats
-# RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
+# Install bats from source
+RUN git clone https://github.com/bats-core/bats-core.git && ./bats-core/install.sh /usr/local
 # Install other bats modules
-RUN npm install -g --save-dev https://github.com/bats-core/bats-support
-RUN npm install -g --save-dev https://github.com/bats-core/bats-assert
+RUN git clone https://github.com/bats-core/bats-support.git
+RUN git clone https://github.com/bats-core/bats-assert.git
+
+# Needed as is mounted later on
+RUN mkdir /root/.ssh
+# Needed for git to run propertly
+RUN touch /root/.gitconfig
 
 WORKDIR /leverage
 # Install requirements for running unit tests
 RUN curl -LO https://raw.githubusercontent.com/binbashar/leverage/master/dev-requirements.txt
 RUN pip install -r dev-requirements.txt
 
-ENTRYPOINT [ "/bin/bash" ]
+# Make script to configure and start docker daemon the default entrypoint
+COPY ./leverage-cli-testing-entrypoint.sh /.
+RUN chmod +x /leverage-cli-testing-entrypoint.sh
+ENTRYPOINT [ "/leverage-cli-testing-entrypoint.sh" ]

--- a/leverage-cli-testing/Makefile
+++ b/leverage-cli-testing/Makefile
@@ -2,7 +2,7 @@
 SHELL			 := /bin/bash
 MAKEFILES_DIR	 := ../@bin/makefiles
 
-DOCKER_TAG		 := 1.0.0
+DOCKER_TAG		 := 2.0.0
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := leverage-cli-testing
 

--- a/leverage-cli-testing/leverage-cli-testing-entrypoint.sh
+++ b/leverage-cli-testing/leverage-cli-testing-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Configure docker daemon to listen through socket
+mkdir /etc/docker
+echo '{"tls": false, "hosts": ["unix:///var/run/docker.sock"]}' > /etc/docker/daemon.json
+
+# Start daemon silently
+dockerd > /dev/null 2>&1 &
+
+exec "$@"


### PR DESCRIPTION
## What?
* Make leverage cli testing image based on Docker-in-Docker official image
* Add entrypoint script for image

## Why?
* Docker-in-Docker approach is needed to run integration tests as close to a real use case as possible

