### PR TITLE
Feature | Updating terratest image to use terraform 1.0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.1.18
+MAKEFILES_VER := v0.1.38
 
 define DOCKER_IMG_LIST
 "ansible" \

--- a/terraform-awscli-terratest-slim/Dockerfile
+++ b/terraform-awscli-terratest-slim/Dockerfile
@@ -19,6 +19,7 @@ ENV PATH /go/bin:$PATH
 
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
+RUN go env -w GO111MODULE=off
 RUN go get github.com/gruntwork-io/terratest/modules/terraform
 RUN go get -u github.com/golang/dep/cmd/dep
 

--- a/terraform-awscli-terratest-slim/Makefile
+++ b/terraform-awscli-terratest-slim/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.15.2
+DOCKER_TAG       :=1.0.9
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli-terratest-slim
 


### PR DESCRIPTION
### Commits on Nov 22, 2021

- Updating terratest image to use terraform 1.0.9 - @exequielrafaela
  
