### PR TITLE
adding timeout statement to build and push circleci commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run:
           name: Build docker images
           command: make build-all
+          no_output_timeout: 30m
 
       - run:
           name: Run docker images tests
@@ -68,6 +69,7 @@ jobs:
       - run:
           name: Build && Push docker images
           command: make build-all && make push-all
+          no_output_timeout: 30m
 
   #
   # Release


### PR DESCRIPTION
## What?

### Commits on Dec 15, 2021
- adding timeout statement to build and push circleci commands - @exequielrafaela

## Why?

- Build failing with time-out => https://app.circleci.com/pipelines/github/binbashar/le-docker-images/254/workflows/807220c7-752f-421a-8f32-61752c286e5f/jobs/404


