### PR TITLE
Feature/buildx multi arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.1.38
+MAKEFILES_VER := v0.2.4
 
 define DOCKER_IMG_LIST
 "ansible" \

--- a/git-release/Dockerfile
+++ b/git-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.9-stretch
+FROM golang:1.17.9-stretch
 
 MAINTAINER Binbash Leverage (info@binbash.com.ar)
 

--- a/git-release/Makefile
+++ b/git-release/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 0.0.2
+DOCKER_TAG       := 0.0.3
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := git-release
 

--- a/terraform-awscli-slim/Makefile
+++ b/terraform-awscli-slim/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       := 1.1.3
+DOCKER_TAG       := 1.2.1
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli-slim
 
@@ -24,7 +24,7 @@ help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
--include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg-multi-arch.mk
 
 #
 # docker run tests

--- a/terraform-awscli-terratest-slim/Makefile
+++ b/terraform-awscli-terratest-slim/Makefile
@@ -2,7 +2,7 @@
 SHELL            := /bin/bash
 MAKEFILES_DIR    := ../@bin/makefiles
 
-DOCKER_TAG       :=1.0.9
+DOCKER_TAG       :=1.1.9
 DOCKER_REPO_NAME := binbash
 DOCKER_IMG_NAME  := terraform-awscli-terratest-slim
 
@@ -10,7 +10,7 @@ help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
--include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg.mk
+-include ${MAKEFILES_DIR}/docker/docker-hub-build-push-single-arg-multi-arch.mk
 
 # terraform & python
 #


### PR DESCRIPTION
## What?

### Commits on May 28, 2022

- [terratest image released for terraform 1.1.3 and 1.1.9 (current tag)](https://github.com/binbashar/le-docker-images/commit/a69c1e4b68f9e7937b5d937198a5744e4b331962) - @[exequielrafaela](https://github.com/binbashar/le-docker-images/commits?author=exequielrafaela)
- [levearge terraform awscli image 1.1.9 and 1.2.1 released and published (new release strategy versioning still pending)](https://github.com/binbashar/le-docker-images/commit/159cf2545d9687110813142e75cde462fea95f50) - @[exequielrafaela](https://github.com/binbashar/le-docker-images/commits?author=exequielrafaela)
- [Makefile pointing to latest makesfiles lib to get docker multi-arch builds](https://github.com/binbashar/le-docker-images/commit/f797dd083187d488664fba8cc4127ac92d860ad9)  - @[exequielrafaela](https://github.com/binbashar/le-docker-images/commits?author=exequielrafaela)

## Why? 

closes https://github.com/binbashar/le-dev-makefiles/issues/28